### PR TITLE
Changes io:format output to error_logger

### DIFF
--- a/src/erldev.erl
+++ b/src/erldev.erl
@@ -15,14 +15,14 @@ make_app([AppDirAtom]) ->
     Modules = get_modules(AppDir),
     AppSrc = try   get_app_src(AppDir)
 	     catch error:{badmatch, _} ->
-%		     io:format("Couldn't get AppSrcFile for ~p~n", [AppDir]),
+%		     error_logger:error_msg("Couldn't get AppSrcFile for ~p~n", [AppDir]),
 		     erlang:halt()
 	     end,
     {application, Name, Opts} = AppSrc,
     NewOpts = [ {modules, Modules} | Opts ],
     AppFile = filename:join([AppDir, "ebin", atom_to_list(Name) ++ ".app"]),
     ok = file:write_file(AppFile, io_lib:format("~p.~n", [{application, Name, NewOpts}])),
-    io:format("Wrote .app contents to: ~p~n", [AppFile]),
+    error_logger:info_msg("Wrote .app contents to: ~p~n", [AppFile]),
     ok.
 
 
@@ -43,6 +43,6 @@ get_modules(AppDir) ->
 get_app_src(AppDir) ->
     [AppSrcFile] = filelib:wildcard(filename:join([AppDir, "src", "*.app.src"])),
     {ok, [AppSrc]} = file:consult(AppSrcFile),
-    %io:format("AppSrc: ~p~n", [AppSrc]),
+    %error_logger:info_msg("AppSrc: ~p~n", [AppSrc]),
     AppSrc.
 

--- a/src/ezic_db_ets.erl
+++ b/src/ezic_db_ets.erl
@@ -110,7 +110,7 @@ create_tables(Filename) ->
     true = ets:insert(rule, Rules),
 
     ets:new(flatzone, [duplicate_bag, named_table]),
-    %% io:format("~p~n", [Rules]),
+    %% error_logger:info_msg("~p~n", [Rules]),
     FlatZones = ezic_flatten:flatten(Zones, Rules),
     true = ets:insert(flatzone, FlatZones),
 

--- a/src/ezic_db_mnesia.erl
+++ b/src/ezic_db_mnesia.erl
@@ -139,7 +139,7 @@ create_tabs(ok) ->
     insert_all(Zones),
     insert_all(Rules),
     FlatZones = ezic_flatten:flatten(Zones, Rules),
-    io:format("~p~n", [FlatZones]),
+    error_logger:info_msg("~p~n", [FlatZones]),
     insert_all(FlatZones),
 
     ok;

--- a/src/ezic_flatten.erl
+++ b/src/ezic_flatten.erl
@@ -53,9 +53,9 @@ ms(Date, Name) ->
     %% 		     , utc_from=SDate, utc_to=SDate
     %% 		     },
     %% {ok, TestResult}= ets:test_ms(TestFZ, MS),
-    %% io:format("TestFZ: ~p~n", [TestFZ]),
-    %% io:format("MS: ~p~n", [MS]),
-    %% io:format("TestResult: ~p~n", [TestResult]),
+    %% error_logger:info_msg("TestFZ: ~p~n", [TestFZ]),
+    %% error_logger:info_msg("MS: ~p~n", [MS]),
+    %% error_logger:info_msg("TestResult: ~p~n", [TestResult]),
 
     MS.
 
@@ -72,7 +72,7 @@ flatten_all_zones(AllZones, AllRules) ->
 flatten_all_zones([], _AllRules, FlatZones) ->
     FlatZones;
 flatten_all_zones([Z1|_]= AllZones, AllRules, FlatZones) ->
-    io:format("Flattening zones: ~s~n", [Z1#zone.name]),
+    error_logger:info_msg("Flattening zones: ~s~n", [Z1#zone.name]),
     {CurrentZones, RestZones}= ezic_zone:split_by_name(Z1, AllZones),
     Flats= flatten_zone_set(CurrentZones, AllRules),
     flatten_all_zones(RestZones, AllRules, Flats ++ FlatZones).
@@ -231,7 +231,7 @@ flatten_rule_set(FlatStart=#flatzone{utc_from=UTCFrom, dstoffset=DSTOffset, offs
 	    end
     catch
 	error:{bad_year,Val} ->
-	    io:format("bad year for EndingRule: ~p~n", [EndingRule]),
+	    error_logger:error_msg("bad year for EndingRule: ~p~n", [EndingRule]),
 	    erlang:error(bad_year, Val)
     end.
 

--- a/src/ezic_loader.erl
+++ b/src/ezic_loader.erl
@@ -43,7 +43,7 @@ parse_dir(Dir) ->
 
 % returns a list of tzdata records from file
 parse_file(File) ->
-    %% io:format("Parsing File: ~p~n", [File]),
+    %% error_logger:info_msg("Parsing File: ~p~n", [File]),
     {ok, FD} = file:open(File, [read]),
     parse_lines(file:read_line(FD), FD, []).
 
@@ -64,7 +64,7 @@ parse_lines({ok, Line}, File, Records) ->
 
 % the Line has data, so we parse it, build a record, and return it
 parse_to_record(Line, _, Records) ->
-    %% io:format("    Parsing Line: ~p~n", [Line]),
+    %% error_logger:info_msg("    Parsing Line: ~p~n", [Line]),
     [Type | Data] = string:tokens(Line, " \t"),
     {ok, PrevType, PrevName} = prev_rec_type(Records),
     {ok, Record} = build_record(Type, Data, {PrevType, PrevName}),


### PR DESCRIPTION
Printing output through io:format is messy since it can't be disabled or redirected. Calls have been rewritten to use error_logger, that supports different handlers and different degrees of severity.
