### PR TITLE
Moves db mod choice to env setting

### DIFF
--- a/src/ezic.app.src
+++ b/src/ezic.app.src
@@ -6,6 +6,6 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, {ezic_app, ezic_db_ets}},
-  {env, [{db_dir, "db"}, {tzdata_dir, "priv/tzdata"}]}
+  {mod, {ezic_app, []}},
+  {env, [{db_mod, ezic_db_ets}, {db_dir, "db"}, {tzdata_dir, "priv/tzdata"}]}
  ]}.

--- a/src/ezic_app.erl
+++ b/src/ezic_app.erl
@@ -25,8 +25,13 @@
 %% OTP design principles as a supervision tree, this means starting the
 %% top supervisor of the tree.
 %%--------------------------------------------------------------------
+
+%% TODO: remove by 2013.09.07 (6 months from today), to allow time for
+%% the transition
+start(_Type, [_]) ->
+    erlang:error("Failed transition to v0.3.0: See Pull Request: https://github.com/drfloob/ezic/pull/15");
 start(_Type, _StartArgs) ->
-  {ok, DbMod} = application:get_env(db_mod),
+    {ok, DbMod} = application:get_env(db_mod),
     case ezic_sup:start_link(DbMod) of
 	{ok, Pid} ->
 	    {ok, Pid};

--- a/src/ezic_app.erl
+++ b/src/ezic_app.erl
@@ -25,8 +25,9 @@
 %% OTP design principles as a supervision tree, this means starting the
 %% top supervisor of the tree.
 %%--------------------------------------------------------------------
-start(_Type, StartArgs) ->
-    case ezic_sup:start_link(StartArgs) of
+start(_Type, _StartArgs) ->
+  {ok, DbMod} = application:get_env(db_mod),
+    case ezic_sup:start_link(DbMod) of
 	{ok, Pid} ->
 	    {ok, Pid};
 	Error ->


### PR DESCRIPTION
Instead of setting what db module to use in the start arguments, it's done through an env setting so it can be easily changed through `set_env` (e.g. when using `application:start` to load it from another app).

(same as #15 but rebased on v0.3.0 branch)
